### PR TITLE
fix the error when using laravel 5.2: Symfony\Component\Debug\Excepti…

### DIFF
--- a/src/php/view.ts
+++ b/src/php/view.ts
@@ -23,6 +23,9 @@ export function getViews(): Promise<string> {
 
 
                 foreach ($filesystem->files($directory) as $file) {
+                    if (!is_object($file) || !method_exists($file, 'getBaseName')) {
+                        continue;
+                    }
                     if (strpos($file->getBaseName(), '.blade.php')) {
                         $fileName = str_replace('.blade.php', '', $file->getBaseName());
                         $views[] = $viewDirectory . '.' . $fileName;
@@ -38,6 +41,9 @@ export function getViews(): Promise<string> {
             $views = [];
 
             foreach ($filesystem->files($path) as $file) {
+                if (!is_object($file) || !method_exists($file, 'getBaseName')) {
+                    continue;
+                }
                 if (strpos($file->getBaseName(), '.blade.php')) {
                     $fileName = str_replace('.blade.php', '', $file->getBaseName());
 


### PR DESCRIPTION
fix the error when using laravel 5.2: 

```
Symfony\Component\Debug\Exception\FatalErrorException: Uncaught Error: Call to a member function getBaseName() on string in Command line code:38
```